### PR TITLE
MP4 tools

### DIFF
--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -15,15 +15,23 @@
    limitations under the License.
 """
 import logging
+import pytest
 import unittest
 
-from construct import Container, ListContainer
+from construct import Container, ListContainer, StreamError
 from pymp4.parser import Box
 
 log = logging.getLogger(__name__)
 
 
 class BoxTests(unittest.TestCase):
+    def test_build_non_fourcc_type(self):
+        with pytest.raises(StreamError) as err_info:
+            Box.build(Container(
+                type=b"MP4",
+            ))
+        assert 'bytes object of wrong length, expected 4, found 3' in err_info.value.args[0]
+
     def test_ftyp_parse(self):
         self.assertEqual(
             Box.parse(b'\x00\x00\x00\x18ftypiso5\x00\x00\x00\x01iso5avc1'),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,8 +14,7 @@ def test_missing_arg(capsys):
     captured = capsys.readouterr()
     assert "the following arguments are required: FILE" in captured.err
 
-def test_dump(capsys):
-    cli.dump(args=[TEST_FILE])
+def __assert_full_dump(capsys):
     captured = capsys.readouterr()
     assert "" == captured.err
     all_types = re.findall(r'type = [^\s]+', captured.out)
@@ -24,15 +23,13 @@ def test_dump(capsys):
     assert captured.out.rstrip().endswith('end = 60')
     assert 'truncated,' not in captured.out
 
+def test_dump(capsys):
+    cli.dump(args=[TEST_FILE])
+    __assert_full_dump(capsys)
+
 def test_full_dump(capsys):
     cli.dump(args=['--full', TEST_FILE])
-    captured = capsys.readouterr()
-    assert "" == captured.err
-    all_types = re.findall(r'type = [^\s]+', captured.out)
-    assert all_types == ["type = b'ftyp'", "type = b'free'"]
-    assert "major_brand = b'M4A ' " in captured.out
-    assert captured.out.rstrip().endswith('end = 60')
-    assert 'truncated,' not in captured.out
+    __assert_full_dump(capsys)
 
 def test_truncated_dump(capsys):
     cli.dump(args=['--truncated', TEST_FILE])
@@ -42,8 +39,7 @@ def test_truncated_dump(capsys):
     assert captured.out.rstrip().endswith('end = 60')
     assert '\\x16\'... (truncated, total 24)' in captured.out
 
-def test_dumping_specific_box(capsys):
-    cli.dump(args=['-b', 'free', TEST_FILE])
+def __assert_free_box_only(capsys):
     captured = capsys.readouterr()
     assert "" == captured.err
 
@@ -54,16 +50,15 @@ def test_dumping_specific_box(capsys):
     assert "type = b'free'" in captured.out
     assert captured.out.rstrip().endswith('end = 60')
     assert "!\"#$' (total 24)" in captured.out
+
+def test_dumping_specific_box(capsys):
+    cli.dump(args=['-b', 'free', TEST_FILE])
+    __assert_free_box_only(capsys)
 
 def test_dumping_specific_box_with_escaped_input(capsys):
     cli.dump(args=['-b', '\\x66ree', TEST_FILE])
-    captured = capsys.readouterr()
-    assert "" == captured.err
+    __assert_free_box_only(capsys)
 
-    all_types = re.findall(r'type = [^\s]+', captured.out)
-    assert all_types == ["type = b'free'"]
-
-    assert "major_brand = b'M4A ' " not in captured.out
-    assert "type = b'free'" in captured.out
-    assert captured.out.rstrip().endswith('end = 60')
-    assert "!\"#$' (total 24)" in captured.out
+def test_dumping_specific_box_with_empty_string(capsys):
+    cli.dump(args=['-b', '', TEST_FILE])
+    __assert_full_dump(capsys)


### PR DESCRIPTION
- Add BoxUtil.search which allows searching for boxes
  - search for multiple box "types" in one call
  - searches children of "found" box if there are any 
  - converts "type" search string to bytes if specified
  - can specify box type and children key to use
    - **Note**: children key will be used for all boxes, i.e. only checks box[children_key] and will not search box['children'].